### PR TITLE
Fix tuple reconstruction

### DIFF
--- a/snake_egg/tests/test_dynamic.py
+++ b/snake_egg/tests/test_dynamic.py
@@ -47,3 +47,4 @@ def test_simplify_add():
     assert simplify(Add(1, 2)) == 3
     assert simplify(Add(1, Add("x", "y"))) == Add(1, Add("x", "y"))
 
+test_simplify_add()

--- a/snake_egg/tests/test_tuple.py
+++ b/snake_egg/tests/test_tuple.py
@@ -1,0 +1,7 @@
+from snake_egg import EGraph
+
+def test_tuple_roundtrip():
+    tup = (1, 2)
+    egraph = EGraph()
+    egraph.add(tup)
+    assert egraph.extract(tup) == tup

--- a/src/core.rs
+++ b/src/core.rs
@@ -1,4 +1,4 @@
-use egg::{AstSize, EGraph, Extractor, Id, Pattern, PatternAst, RecExpr, Rewrite, Runner, Var};
+use egg::{AstSize, EGraph, Extractor, Id, Language, Pattern, PatternAst, RecExpr, Rewrite, Runner, Var};
 use pyo3::types::{PyList, PyString, PyTuple};
 use pyo3::{basic::CompareOp, prelude::*};
 
@@ -190,6 +190,12 @@ impl PyEGraph {
                 reconstruct(py, &recexpr)
             })
             .collect()
+    }
+
+    fn dump(&self) -> PyResult<()> {
+        let dump = self.egraph.dump();
+        println!("{:?}", dump);
+        Ok(())
     }
 }
 pub(crate) fn reconstruct(py: Python, recexpr: &RecExpr<PythonNode>) -> PyObject {


### PR DESCRIPTION
There was an issue where we inserted a (non-named) tuple into the e-graph, it'd call the constructor with the unpacked arguments. We should pass in an Iterable (i.e. packed) instead in this case.